### PR TITLE
schedule 중복 제거 및 pdf업로드시 과거 년도/학기도 반영하게 업그레이드

### DIFF
--- a/backend/db/schedule.js
+++ b/backend/db/schedule.js
@@ -25,7 +25,7 @@ const scheduleSchema = new mongoose.Schema({
     type: Date,
     required: true
   }
-}, { collection: 'schedule' });
+}, { collection: 'schedule', versionKey: false });
 
 // class DB 연결된 mongoose 인스턴스에서 모델 생성
 const Schedule = global.classDB.model('Schedule', scheduleSchema);

--- a/backend/python/klas_lecture.py
+++ b/backend/python/klas_lecture.py
@@ -22,10 +22,14 @@ chrome_options.add_argument("--disable-dev-shm-usage")
 
 # 인자 체크
 if len(sys.argv) < 2:
-    print("사용법: python klas_lecture.py 2025-1")
+    # print("사용법: python klas_lecture.py 2025-1")
     sys.exit(1)
 
 collection_name = sys.argv[1]
+
+# 연도 및 학기 파싱
+year, semester = collection_name.split("-")
+season_text = "1학기" if semester == "1" else "2학기"
 
 load_dotenv()
 
@@ -138,6 +142,26 @@ try:
 
     driver.get("https://klas.kw.ac.kr/std/cps/atnlc/LectrePlanStdPage.do")
     time.sleep(3)
+
+    # 연도 선택
+    year_dropdown = driver.find_element(By.XPATH, '//*[@id="selectYear"]')
+    year_dropdown.click()
+    time.sleep(1)
+    year_options = driver.find_elements(By.XPATH, '//*[@id="selectYear"]/option')
+    for y in year_options:
+        if y.text.strip().startswith(year):
+            y.click()
+            break
+
+    # 학기 선택
+    term_dropdown = driver.find_element(By.XPATH, '//*[@id="selecthakgi"]')
+    term_dropdown.click()
+    time.sleep(1)
+    term_options = driver.find_elements(By.XPATH, '//*[@id="selecthakgi"]/option')
+    for t in term_options:
+        if season_text in t.text.strip():
+            t.click()
+            break
 
     page_size = 100
     total_courses = collection.count_documents({})

--- a/backend/python/season_klas.py
+++ b/backend/python/season_klas.py
@@ -183,5 +183,4 @@ if __name__ == "__main__":
 
     collection_name = sys.argv[1]
     crawl_season(collection_name)
-    # input("크롤링이 완료되었습니다. Enter 키를 누르면 브라우저가 종료됩니다...")
     driver.quit()

--- a/backend/routes/pdfupload.js
+++ b/backend/routes/pdfupload.js
@@ -64,18 +64,15 @@ router.post('/upload', upload.single('pdf'), async (req, res) => {
     const start_time = new Date(startDate);
     const end_time = new Date(endDate);
 
-    const newSchedule = new Schedule({
-      year,
-      semester: semesterStr,
-      start_time,
-      end_time,
-    });
+    await Schedule.findOneAndUpdate(
+    { year, semester: semesterStr },
+    { start_time, end_time },
+    { upsert: true, new: true }, { versionKey : false});
 
-    await newSchedule.save();
     console.log(`MongoDB에 schedule 저장 완료: ${semester}`);
   } catch (dbErr) {
-    console.error('MongoDB 저장 실패:', dbErr);
-    return res.status(500).json({ error: '스케줄 저장 실패', detail: dbErr.message });
+  console.error('MongoDB 저장 실패:', dbErr);
+  return res.status(500).json({ error: '스케줄 저장 실패', detail: dbErr.message });
   }
 
   const scriptDir = path.join(__dirname, '..', 'python');


### PR DESCRIPTION
기존에 pdf 업로드하고 개강일과 종강일을 입력할때, 기존에 데이터가 있어도 추가되는 방식이지만, 이미 해당하는 값이 db에 존재한다면 year 와 semester를 확인하고 동일한경우, 이전의 값을 없애고 새로 입력한 값으로 대체한다.

또한, 정규학기 pdf upload시 년도와 학기 부분을 크롤링 할 때, 한 번 더 확인하는 검증을 거치며 정확한 반영을 위한 성능 개선을 하였다. 